### PR TITLE
Copy `npm` to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apk add --no-cache -v --virtual .build-deps \
 # Install Node.js
 # https://github.com/mhart/alpine-node#example-dockerfile-for-your-own-nodejs-project
 COPY --from=node /usr/bin/node /usr/bin/
+COPY --from=node /usr/bin/npm /usr/bin/
 COPY --from=node /usr/lib/libgcc* /usr/lib/libstdc* /usr/lib/
 
 COPY --from=node /usr/local/share/yarn /usr/local/share/yarn


### PR DESCRIPTION
`yarn` 대신 `npm`을 사용하는 경우를 위해 추가